### PR TITLE
Fix minversion of macOS CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       if:    runner.os == 'Linux'
       run:   |
         cd src
-        make -j2 CFLAGS_COMMON="-fms-extensions -static" LDFLAGS_COMMON="-lm -static"
+        make -j2 CFLAGS_EXTRA="-static" LDFLAGS_EXTRA="-static"
     - name:  Build [macOS]
       if:    runner.os == 'macOS'
       run:   |
@@ -53,7 +53,7 @@ jobs:
       run:   |
         cd src
         export PATH="/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw32/bin:$PATH"
-        mingw32-make -j2 CFLAGS_COMMON="-fms-extensions -static" LDFLAGS_COMMON="-lm -static"
+        mingw32-make -j2 CFLAGS_EXTRA="-static" LDFLAGS_EXTRA="-static"
 
     - name: Test (Launching binaries)
       run:  |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       if:    runner.os == 'Linux'
       run:   |
         cd src
-        make -j2 CFLAGS_COMMON="-fms-extensions -static" LDFLAGS_COMMON="-lm -static"
+        make -j2 CFLAGS_EXTRA="-static" LDFLAGS_EXTRA="-static"
     - name:  Build [macOS]
       if:    runner.os == 'macOS'
       run:   |
@@ -54,7 +54,7 @@ jobs:
       run:   |
         cd src
         export PATH="/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw32/bin:$PATH"
-        mingw32-make -j2 CFLAGS_COMMON="-fms-extensions -static" LDFLAGS_COMMON="-lm -static"
+        mingw32-make -j2 CFLAGS_EXTRA="-static" LDFLAGS_EXTRA="-static"
 
     - name: Test (Launching binaries)
       run:  |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 vgmck
 vgmck_d
 
+*.vgm

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,13 +24,26 @@ MAIN_DEBUG ?= vgmck_d
 
 CC             = gcc
 
+OSX_MINVERSION ?= 10.6
+
 CFLAGS_COMMON  ?= -fms-extensions
 LDFLAGS_COMMON ?= -lm
 
-CFLAGS         ?= $(CFLAGS_COMMON) -O2
-CFLAGS_DEBUG   ?= $(CFLAGS_COMMON) -g
-LDFLAGS        ?= $(LDFLAGS_COMMON) -s -O2
-LDFLAGS_DEBUG  ?= $(LDFLAGS_COMMON) -g
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		CFLAGS_COMMON  += -mmacosx-version-min=$(OSX_MINVERSION)
+		LDFLAGS_COMMON += -mmacosx-version-min=$(OSX_MINVERSION)
+	endif
+endif
+
+CFLAGS_EXTRA   ?=
+LDFLAGS_EXTRA  ?=
+
+CFLAGS         ?= $(CFLAGS_COMMON) $(CFLAGS_EXTRA) -O2
+CFLAGS_DEBUG   ?= $(CFLAGS_COMMON) $(CFLAGS_EXTRA) -g
+LDFLAGS        ?= $(LDFLAGS_COMMON) $(LDFLAGS_EXTRA) -s -O2
+LDFLAGS_DEBUG  ?= $(LDFLAGS_COMMON) $(LDFLAGS_EXTRA) -g
 
 .PHONY: all clean
 


### PR DESCRIPTION
macOS artifacts are by default bound to the version of macOS they were compiled on, which appears to be 10.15 Catalina. Adds `-mmacosx-version-min=` switch to specify minimum version. Execution on non-10.15 untested.